### PR TITLE
graph database

### DIFF
--- a/lib/holistic/database/graph.rb
+++ b/lib/holistic/database/graph.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# nodes
+# 
+# files
+# scopes
+# references
+#
+# relations
+#
+# file -> defines many -> scopes (n-n)
+# file -> defines many -> references (1-n)
+# scope -> contains many -> scopes (1-n)
+# scope -> defines many -> references (1-n)
+# scope -> is referenced by many -> references (1-n)
+#
+# database = Graph.new
+# file = database.store({ id: "/path/to/myfile.rb", last_modified_at: 1234 })
+# node = database.store({ id: "::MyApp::Something", key: "value" })
+#
+# file_node = database.store("/path/to/myfile.rb", { last_modified_at: 1234 })
+# database.relate(file_node, reference_node, :definition)
+# 
+class Holistic::Database::Graph
+  Node = ::Struct.new(
+    :attributes,
+    :relations,
+    keyword_init: true
+  )
+
+  def initialize
+    @nodes = {}
+    @indices = {}
+  end
+
+  def store(id, attributes)
+    @nodes[id] = Node.new(attributes:, relations: {})
+  end
+end


### PR DESCRIPTION
the current database implementation indexes attributes needed for o(1) lookups. Each kind of data has a custom type (Scope::Record, Reference::Record, Document::Location) and the hash stored in the database points to this record. This custom-type record have relations to other records that lives outside of the database.

**problem:** there is no single place to serialize the state of the application. This is important to avoid re-indexing the code base every time the user opens the editor.

**what can I do about it?**: move all data to the database. But in order to keep algorithms efficient, the database will have to store relations between records. All the usual primitive types + pointer to other records like a graph database. With that, I'll have a single place for all structured data that can be dumped.

```
# types of nodes

files
scopes
references

# relations

file -> defines many -> scopes (n-n)
file -> defines many -> references (1-n)
scope -> contains many -> scopes (1-n)
scope -> defines many -> references (1-n)
scope -> is referenced by many -> references (1-n)
```