### PR TITLE
read content from disk on `textDocument/didSave`

### DIFF
--- a/lib/holistic/document/unsaved/record.rb
+++ b/lib/holistic/document/unsaved/record.rb
@@ -37,7 +37,10 @@ module Holistic::Document
     end
 
     def mark_as_saved!
-      @original_content = @content.dup
+      ::File.read(path).tap do |content_from_disk|
+        @original_content = content_from_disk
+        @content = content_from_disk
+      end
     end
 
     def restore_original_content!

--- a/spec/holistic/document/unsaved/record/has_unsaved_changes_spec.rb
+++ b/spec/holistic/document/unsaved/record/has_unsaved_changes_spec.rb
@@ -13,6 +13,7 @@ describe ::Holistic::Document::Unsaved::Record do
 
       expect(document.has_unsaved_changes?).to be(true)
 
+      expect(::File).to receive(:read).and_return("acontent")
       document.mark_as_saved!
 
       expect(document.has_unsaved_changes?).to be(false)


### PR DESCRIPTION
## What problem does it solve?

We cannot trust client editors to always deliver messages in the original order performed by the user without any losses. One of the most frequent message is `textDocument/didChange` witth the change delta. We update our in-memory text data for the document being changed in `Document::Unsaved::Record#apply_change`, but sometimes things get out of sync, which is fixed by closing and opening the file.

Reading from disk on `textDocument/didSave` fixes all problems to delta sync.

## Treating the symptom, not the cause

I don't feel great about this because we might hide potential bugs with deltas in `apply_change`. But, faulty clients exist and reading from disk makes the process more robust.